### PR TITLE
Add NECB footprint aspect ratio option

### DIFF
--- a/lib/openstudio-standards/btap/geometry.rb
+++ b/lib/openstudio-standards/btap/geometry.rb
@@ -58,6 +58,45 @@ module BTAP
       return model
     end
 
+    def self.model_horizontal_dimensions(model)
+      bounding_box = OpenStudio::BoundingBox.new
+      model.getSpaces.each do |space|
+        space.surfaces.each do |surface|
+          bounding_box.addPoints(space.transformation * surface.vertices)
+        end
+      end
+
+      raise ArgumentError, 'Cannot calculate footprint dimensions for a model without space geometry.' if bounding_box.isEmpty
+
+      x_dimension = bounding_box.maxX.get - bounding_box.minX.get
+      y_dimension = bounding_box.maxY.get - bounding_box.minY.get
+      if x_dimension <= 0.0 || y_dimension <= 0.0
+        raise ArgumentError, 'Building footprint dimensions must be greater than zero.'
+      end
+
+      return x_dimension, y_dimension
+    end
+
+    def self.set_footprint_aspect_ratio(model, target_aspect_ratio)
+      target_aspect_ratio = target_aspect_ratio.to_f
+      unless target_aspect_ratio.finite? && target_aspect_ratio >= 1.0
+        raise ArgumentError, 'Footprint aspect ratio must be a finite number greater than or equal to 1.0.'
+      end
+
+      x_dimension, y_dimension = model_horizontal_dimensions(model)
+      current_aspect_ratio = [x_dimension, y_dimension].max / [x_dimension, y_dimension].min
+      major_axis_scale = Math.sqrt(target_aspect_ratio / current_aspect_ratio)
+      minor_axis_scale = 1.0 / major_axis_scale
+
+      if x_dimension >= y_dimension
+        scale_model(model, major_axis_scale, minor_axis_scale, 1.0)
+      else
+        scale_model(model, minor_axis_scale, major_axis_scale, 1.0)
+      end
+
+      return model
+    end
+
     def self.get_fwdr(model)
       outdoor_surfaces = BTAP::Geometry::Surfaces::filter_by_boundary_condition(model.getSurfaces(), "Outdoors")
       outdoor_walls = BTAP::Geometry::Surfaces::filter_by_surface_types(outdoor_surfaces, "Wall")

--- a/lib/openstudio-standards/btap/qaqc/datapoint.rb
+++ b/lib/openstudio-standards/btap/qaqc/datapoint.rb
@@ -154,6 +154,7 @@ module BTAP
             scale_x: @options[:scale_x],
             scale_y: @options[:scale_y],
             scale_z: @options[:scale_z],
+            footprint_aspect_ratio: @options[:footprint_aspect_ratio],
             pv_ground_type: @options[:pv_ground_type],
             pv_ground_total_area_pv_panels_m2: @options[:pv_ground_total_area_pv_panels_m2],
             pv_ground_tilt_angle: @options[:pv_ground_tilt_angle],

--- a/lib/openstudio-standards/standards/necb/NECB2011/necb_2011.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/necb_2011.rb
@@ -292,6 +292,7 @@ class NECB2011 < Standard
                                    scale_x: nil,
                                    scale_y: nil,
                                    scale_z: nil,
+                                   footprint_aspect_ratio: nil,
                                    pv_ground_type: nil,
                                    pv_ground_total_area_pv_panels_m2: nil,
                                    pv_ground_tilt_angle: nil,
@@ -364,6 +365,7 @@ class NECB2011 < Standard
                                 scale_x: scale_x,
                                 scale_y: scale_y,
                                 scale_z: scale_z,
+                                footprint_aspect_ratio: footprint_aspect_ratio,
                                 pv_ground_type: pv_ground_type, # Two options: (1) nil/none/false/'NECB_Default', (2) 'add_pv_ground'
                                 pv_ground_total_area_pv_panels_m2: pv_ground_total_area_pv_panels_m2, # Options: (1) nil/none/false, (2) 'NECB_Default' (i.e. building footprint), (3) area value (e.g. 50)
                                 pv_ground_tilt_angle: pv_ground_tilt_angle, # Options: (1) nil/none/false, (2) 'NECB_Default' (i.e. latitude), (3) tilt angle value (e.g. 20)
@@ -447,6 +449,7 @@ class NECB2011 < Standard
                            scale_x: nil,
                            scale_y: nil,
                            scale_z: nil,
+                           footprint_aspect_ratio: nil,
                            nv_type: nil,
                            nv_opening_fraction: nil,
                            nv_temp_out_min: nil,
@@ -480,7 +483,12 @@ class NECB2011 < Standard
     primary_heating_fuel = validate_primary_heating_fuel(primary_heating_fuel: primary_heating_fuel, model: model)
     self.fuel_type_set = SystemFuels.new()
     self.fuel_type_set.set_defaults(standards_data: @standards_data, primary_heating_fuel: primary_heating_fuel)
-    clean_and_scale_model(model: model, rotation_degrees: rotation_degrees, scale_x: scale_x, scale_y: scale_y, scale_z: scale_z)
+    clean_and_scale_model(model: model,
+                rotation_degrees: rotation_degrees,
+                scale_x: scale_x,
+                scale_y: scale_y,
+                scale_z: scale_z,
+                footprint_aspect_ratio: footprint_aspect_ratio)
 
     ext_floor_cond           = convert_arg_to_f(variable: ext_floor_cond, default: nil)
     ext_roof_cond            = convert_arg_to_f(variable: ext_roof_cond, default: nil)
@@ -607,7 +615,7 @@ class NECB2011 < Standard
   end
 
   # This method cleans the model of any existing HVAC systems and applies any desired ratation or scaling to the model.
-  def clean_and_scale_model(model:, rotation_degrees: nil, scale_x: nil, scale_y: nil, scale_z: nil)
+  def clean_and_scale_model(model:, rotation_degrees: nil, scale_x: nil, scale_y: nil, scale_z: nil, footprint_aspect_ratio: nil)
     # clean model..
     BTAP::Resources::Envelope::remove_all_envelope_information(model)
     model = OpenstudioStandards::HVAC.remove_all_hvac(model)
@@ -631,9 +639,6 @@ class NECB2011 < Standard
     model.getSpaces.sort.each { |space| space.designSpecificationOutdoorAir(&:remove) }
     model.getThermostatSetpointDualSetpoints.each(&:remove)
 
-    scale_x = 1.0
-    scale_y = 1.0
-    scale_z = 1.0
     # Rotate to model if requested
     rotation_degrees = convert_arg_to_f(variable: rotation_degrees, default: 0.0)
     BTAP::Geometry.rotate_building(model: model, degrees: rotation_degrees) unless rotation_degrees == 0.0
@@ -642,9 +647,10 @@ class NECB2011 < Standard
     scale_x = convert_arg_to_f(variable: scale_x, default: 1.0)
     scale_y = convert_arg_to_f(variable: scale_y, default: 1.0)
     scale_z = convert_arg_to_f(variable: scale_z, default: 1.0)
-    return unless scale_x != 1.0 || scale_y != 1.0 || scale_z != 1.0
+    BTAP::Geometry.scale_model(model, scale_x, scale_y, scale_z) if scale_x != 1.0 || scale_y != 1.0 || scale_z != 1.0
 
-    BTAP::Geometry.scale_model(model, scale_x, scale_y, scale_z)
+    footprint_aspect_ratio = convert_arg_to_f(variable: footprint_aspect_ratio, default: nil)
+    BTAP::Geometry.set_footprint_aspect_ratio(model, footprint_aspect_ratio) unless footprint_aspect_ratio.nil?
   end
 
   def apply_systems_and_efficiencies(model:,

--- a/test/necb/unit_tests/tests/test_necb_geometry_options.rb
+++ b/test/necb/unit_tests/tests/test_necb_geometry_options.rb
@@ -1,0 +1,29 @@
+require_relative '../../../helpers/minitest_helper'
+
+class NECB_Geometry_Options_Tests < Minitest::Test
+  def setup
+    @standard = Standard.build('NECB2011')
+  end
+
+  def test_clean_and_scale_model_applies_scale_arguments
+    model = @standard.load_building_type_from_library(building_type: 'SmallOffice')
+    original_x, original_y = BTAP::Geometry.model_horizontal_dimensions(model)
+
+    @standard.clean_and_scale_model(model: model, scale_x: 2.0, scale_y: 1.0, scale_z: 1.0)
+
+    scaled_x, scaled_y = BTAP::Geometry.model_horizontal_dimensions(model)
+    assert_in_delta(original_x * 2.0, scaled_x, 0.001)
+    assert_in_delta(original_y, scaled_y, 0.001)
+  end
+
+  def test_clean_and_scale_model_applies_footprint_aspect_ratio
+    model = @standard.load_building_type_from_library(building_type: 'SmallOffice')
+    original_floor_area = model.getBuilding.floorArea
+
+    @standard.clean_and_scale_model(model: model, footprint_aspect_ratio: 3.0)
+
+    x_dimension, y_dimension = BTAP::Geometry.model_horizontal_dimensions(model)
+    assert_in_delta(3.0, [x_dimension, y_dimension].max / [x_dimension, y_dimension].min, 0.001)
+    assert_in_delta(original_floor_area, model.getBuilding.floorArea, 0.001)
+  end
+end

--- a/test/necb/unit_tests/tests/test_necb_geometry_scaling.rb
+++ b/test/necb/unit_tests/tests/test_necb_geometry_scaling.rb
@@ -1,0 +1,91 @@
+$LOAD_PATH.unshift File.expand_path('../../../../lib', __dir__)
+
+require 'minitest/autorun'
+require 'openstudio'
+require_relative '../../../../lib/openstudio-standards/btap/geometry'
+
+class NECB_Geometry_Scaling_Tests < Minitest::Test
+  def test_scale_model_uses_dimension_multipliers
+    model = rectangular_model(length: 10.0, width: 5.0)
+
+    BTAP::Geometry.scale_model(model, 2.0, 1.0, 1.0)
+
+    length, width = horizontal_dimensions(model)
+    assert_in_delta(20.0, length, 0.001)
+    assert_in_delta(5.0, width, 0.001)
+  end
+
+  def test_set_footprint_aspect_ratio_preserves_area_and_height
+    model = rectangular_model(length: 10.0, width: 5.0)
+    original_floor_area = model.getBuilding.floorArea
+    original_height = model.getBuilding.airVolume / original_floor_area
+
+    BTAP::Geometry.set_footprint_aspect_ratio(model, 4.0)
+
+    length, width = horizontal_dimensions(model)
+    assert_in_delta(4.0, length / width, 0.001)
+    assert_in_delta(original_floor_area, model.getBuilding.floorArea, 0.001)
+    assert_in_delta(original_height, model.getBuilding.airVolume / model.getBuilding.floorArea, 0.001)
+  end
+
+  def test_set_footprint_aspect_ratio_rejects_values_below_one
+    model = rectangular_model(length: 10.0, width: 5.0)
+
+    assert_raises(ArgumentError) do
+      BTAP::Geometry.set_footprint_aspect_ratio(model, 0.5)
+    end
+  end
+
+  def test_horizontal_dimensions_rejects_empty_model
+    assert_raises(ArgumentError) do
+      BTAP::Geometry.model_horizontal_dimensions(OpenStudio::Model::Model.new)
+    end
+  end
+
+  def test_set_footprint_aspect_ratio_preserves_archetype_topology
+    model = load_archetype('SmallOffice')
+    original_floor_area = model.getBuilding.floorArea
+    original_matched_surfaces = matched_surface_count(model)
+
+    BTAP::Geometry.set_footprint_aspect_ratio(model, 3.0)
+
+    length, width = horizontal_dimensions(model)
+    assert_in_delta(3.0, [length, width].max / [length, width].min, 0.001)
+    assert_in_delta(original_floor_area, model.getBuilding.floorArea, 0.001)
+    assert_equal(original_matched_surfaces, matched_surface_count(model))
+  end
+
+  private
+
+  def rectangular_model(length:, width:)
+    model = OpenStudio::Model::Model.new
+    points = OpenStudio::Point3dVector.new
+    points << OpenStudio::Point3d.new(0.0, 0.0, 0.0)
+    points << OpenStudio::Point3d.new(0.0, width, 0.0)
+    points << OpenStudio::Point3d.new(length, width, 0.0)
+    points << OpenStudio::Point3d.new(length, 0.0, 0.0)
+    OpenStudio::Model::Space.fromFloorPrint(points, 3.0, model).get
+    model
+  end
+
+  def horizontal_dimensions(model)
+    bounding_box = OpenStudio::BoundingBox.new
+    model.getSpaces.each do |space|
+      space.surfaces.each do |surface|
+        bounding_box.addPoints(space.transformation * surface.vertices)
+      end
+    end
+
+    [bounding_box.maxX.get - bounding_box.minX.get,
+     bounding_box.maxY.get - bounding_box.minY.get]
+  end
+
+  def load_archetype(building_type)
+    path = File.expand_path("../../../../lib/openstudio-standards/standards/necb/NECB2011/data/geometry/#{building_type}.osm", __dir__)
+    OpenStudio::OSVersion::VersionTranslator.new.loadModel(OpenStudio::Path.new(path)).get
+  end
+
+  def matched_surface_count(model)
+    model.getSurfaces.count { |surface| surface.outsideBoundaryCondition == 'Surface' }
+  end
+end


### PR DESCRIPTION
Pull request overview

Adds support for changing an NECB building archetype's footprint aspect ratio while preserving its total floor area and height.

The footprint aspect ratio is defined as the longest horizontal building extent divided by the shortest horizontal building extent. The implementation scales the major and minor axes proportionally so that their scale-factor product remains `1.0`.

This pull request:

- Adds methods to calculate model footprint dimensions and apply a target aspect ratio.
- Passes `footprint_aspect_ratio` through the BTAP datapoint and NECB model APIs.
- Applies the transformation before envelope, zoning, sizing, and HVAC processing.
- Fixes an existing defect where `scale_x`, `scale_y`, and `scale_z` inputs were overwritten with `1.0` and therefore ignored.
- Adds unit and NECB integration tests.

---------------------

### Pull Request Author
@navidshh 


 - [*] Method changes or additions
 - [ ] Data changes or additions
 - [*] Added tests for added methods
 - [ ] If methods have been deprecated, update rest of code to use the new methods
 - [ ] Documented new methods using [yard syntax](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md)
 - [ ] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [ ] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [ ] All new and existing tests passes
 - [*] If the code adds new `require` statements, ensure these are in core ruby or add to the gemspec

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [*] Perform a code review on GitHub
 - [*] All related changes have been implemented: method additions, changes, tests
 - [ ] Check rubocop errors
 - [*] Check yard doc errors
 - [*] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [*] If a new feature, test the new feature and try creative ways to break it
 - [ ] CI status: all green or justified

All 511 yard tests passed. 