### PR TITLE
Parse standards data tables on first use instead of at build time

### DIFF
--- a/lib/openstudio-standards.rb
+++ b/lib/openstudio-standards.rb
@@ -170,6 +170,7 @@ module OpenstudioStandards
 
   ### Standards ###
   # Standards classes
+  require_relative "#{stds}/lazy_standards_data"
   require_relative "#{stds}/standard"
   # NECB2011 Code
   require_relative "#{stds}/necb/NECB2011/system_fuels"

--- a/lib/openstudio-standards/standards/lazy_standards_data.rb
+++ b/lib/openstudio-standards/standards/lazy_standards_data.rb
@@ -1,0 +1,239 @@
+class Standard
+  # Holds the JSON data tables for a Standard and parses each table
+  # the first time it is requested rather than when the Standard is built.
+  #
+  # Every JSON data file holds exactly one top-level table, named by the
+  # last dot-separated part of the file name (for example
+  # ashrae_90_1_2013.boilers.json holds the 'boilers' table). A few files use
+  # an abbreviated suffix; those are mapped through SUFFIX_ALIASES.
+  #
+  # Data directories are searched in the order given. When several directories
+  # provide the same table, the last directory wins, which lets a subclass
+  # override the tables of its parent standard.
+  #
+  # The object answers the Hash methods the rest of the library uses on
+  # standards data ([], []=, key?, keys, ...), so callers do not need to know
+  # that the tables are parsed on demand.
+  class LazyStandardsData
+    include Enumerable
+
+    # File name suffixes whose JSON table name differs from the suffix
+    SUFFIX_ALIASES = {
+      'spc_typ' => 'space_types',
+      'ext_ltg' => 'exterior_lighting',
+      'prm_ext_ltg' => 'prm_exterior_lighting',
+      'ref_cases' => 'refrigerated_cases',
+      'ref_lnup' => 'refrigeration_system_lineup'
+    }.freeze
+
+    # @param standard [Standard] the standard that owns the data; its template
+    #   is written into every table object that carries a 'template' field
+    # @param data_directories [Array<String>] directories whose data/*.json files
+    #   supply the tables, from the most generic to the most specific
+    # @param embedded [Boolean, nil] true when the files live inside the OpenStudio
+    #   CLI's embedded file system; detected from this file's location when nil
+    def initialize(standard, data_directories = [], embedded: nil)
+      @standard = standard
+      @embedded = embedded.nil? ? __dir__[0] == ':' : embedded
+      @index = {}
+      @loaded = {}
+      data_directories.each { |data_dir| add_directory(data_dir) }
+    end
+
+    # The template written into each table's objects
+    #
+    # @return [String]
+    def template
+      @standard.template
+    end
+
+    # Registers every JSON file in a directory's data folder. Tables already
+    # registered from an earlier directory are overridden.
+    #
+    # @param data_dir [String] directory containing a data folder of JSON files
+    # @return [Array<String>] the table names supplied by the directory
+    def add_directory(data_dir)
+      files = @embedded ? embedded_json_files(data_dir) : local_json_files(data_dir)
+      files.map do |file|
+        table_name = self.class.table_name_for(file)
+        if @index.key?(table_name)
+          OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.standard', "Overriding #{table_name} with #{File.basename(file)}")
+        else
+          OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.standard', "Adding #{table_name} from #{File.basename(file)}")
+        end
+        @index[table_name] = file
+        @loaded.delete(table_name)
+        table_name
+      end
+    end
+
+    # The table name a data file supplies, derived from its file name
+    #
+    # @param file [String] path to a JSON data file
+    # @return [String] table name
+    def self.table_name_for(file)
+      suffix = File.basename(file, '.json').split('.').last
+      SUFFIX_ALIASES.fetch(suffix, suffix)
+    end
+
+    # Returns a table, parsing its file on first access.
+    #
+    # @param table_name [String]
+    # @return [Array<Hash>, nil] the table, or nil when no file supplies it
+    def [](table_name)
+      return @loaded[table_name] if @loaded.key?(table_name)
+      return nil unless @index.key?(table_name)
+
+      @loaded[table_name] = parse_table(table_name, @index[table_name])
+    end
+
+    # Stores a table directly, replacing any file-backed table of the same name
+    #
+    # @param table_name [String]
+    # @param objs [Array<Hash>]
+    def []=(table_name, objs)
+      @loaded[table_name] = objs
+    end
+
+    # @see Hash#fetch
+    def fetch(table_name, *default, &block)
+      return self[table_name] if key?(table_name)
+      return block.call(table_name) if block
+      return default.first unless default.empty?
+
+      raise KeyError, "table not found: #{table_name}"
+    end
+
+    # @see Hash#dig
+    def dig(table_name, *rest)
+      table = self[table_name]
+      return table if rest.empty? || table.nil?
+
+      table.dig(*rest)
+    end
+
+    # @return [Boolean] true when a file supplies the table or it was stored directly
+    def key?(table_name)
+      @loaded.key?(table_name) || @index.key?(table_name)
+    end
+    alias has_key? key?
+    alias include? key?
+    alias member? key?
+
+    # @return [Boolean] true when the table has already been parsed or stored
+    def loaded?(table_name)
+      @loaded.key?(table_name)
+    end
+
+    # @return [Array<String>] names of every available table
+    def keys
+      @index.keys | @loaded.keys
+    end
+
+    # @return [Array<String>] names of the tables that have been parsed or stored
+    def loaded_tables
+      @loaded.keys
+    end
+
+    # @return [String, nil] the file that supplies a table, or nil if it was stored directly
+    def file_for(table_name)
+      @index[table_name]
+    end
+
+    # @return [Boolean]
+    def empty?
+      keys.empty?
+    end
+
+    # @return [Integer] number of available tables
+    def size
+      keys.size
+    end
+    alias length size
+
+    # Removes a table so that it is no longer available
+    #
+    # @return [Array<Hash>, nil] the removed table if it had been loaded
+    def delete(table_name)
+      @index.delete(table_name)
+      @loaded.delete(table_name)
+    end
+
+    # Parses every table that has not been loaded yet
+    #
+    # @return [LazyStandardsData] self
+    def load_all
+      @index.each_key { |table_name| self[table_name] }
+      self
+    end
+
+    # Yields every table, parsing any that are not loaded yet
+    #
+    # @yield [table_name, objs]
+    def each_pair(&block)
+      return enum_for(:each_pair) unless block
+
+      keys.each { |table_name| block.call(table_name, self[table_name]) }
+    end
+    alias each each_pair
+
+    # @return [Array<Array<Hash>>] every table, parsing any that are not loaded yet
+    def values
+      keys.map { |table_name| self[table_name] }
+    end
+
+    # @return [Hash] a plain hash of every table, parsing any that are not loaded yet
+    def to_h
+      keys.to_h { |table_name| [table_name, self[table_name]] }
+    end
+
+    # @return [String] a short description that does not dump the tables
+    def inspect
+      "#<#{self.class.name} template=#{template.inspect} tables=#{keys.size} loaded=#{@loaded.size}>"
+    end
+
+    private
+
+    # @return [Array<String>] JSON files in the data folder of a local directory
+    def local_json_files(data_dir)
+      OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.standard', "Indexing JSON files from #{data_dir}")
+      Dir.glob("#{data_dir}/data/*.json").select { |file| File.file?(file) }.sort
+    end
+
+    # @return [Array<String>] JSON files in the data folder of an OpenStudio CLI embedded directory
+    def embedded_json_files(data_dir)
+      OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.standard', "Indexing JSON files from OpenStudio CLI embedded directory #{data_dir}")
+      EmbeddedScripting.allFileNamesAsString.split(';').select do |file|
+        file.start_with?("#{data_dir}/data/") && file.end_with?('.json')
+      end.sort
+    end
+
+    # @return [String] the contents of a data file
+    def read_file(file)
+      @embedded ? EmbeddedScripting.getFileAsString(file) : File.read(file)
+    end
+
+    # Parses a data file and returns the named table with its template fields
+    # set to this standard's template
+    #
+    # @return [Array<Hash>]
+    def parse_table(table_name, file)
+      OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.standard', "Loading #{table_name} from #{File.basename(file)}")
+      data = JSON.parse(read_file(file))
+      objs = data[table_name]
+      if objs.nil?
+        OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.standard', "#{File.basename(file)} is expected to hold the '#{table_name}' table but holds #{data.keys.inspect}; rename the file to match its table.")
+        objs = data.values.first
+      elsif data.size > 1
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.standard', "#{File.basename(file)} holds #{data.keys.inspect}; only '#{table_name}' is used. Put each table in its own file.")
+      end
+      return objs unless objs.is_a?(Array)
+
+      # Override the template in inherited files to match the instantiated template
+      objs.each do |obj|
+        obj['template'] = template if obj.is_a?(Hash) && obj.key?('template')
+      end
+      return objs
+    end
+  end
+end

--- a/lib/openstudio-standards/standards/standard.rb
+++ b/lib/openstudio-standards/standards/standard.rb
@@ -69,65 +69,17 @@ class Standard
   # For example, data from ASHRAE 90.1-2004 will be overridden by
   # data from ComStock ASHRAE 90.1-2004.
   #
+  # Only the list of available tables is built here. Each table's JSON file
+  # is parsed the first time the table is requested from standards_data.
+  #
   # @param data_directories [Array<String>] array of file paths that contain standards data
-  # @return [Hash] a hash of standards data
+  # @return [Standard::LazyStandardsData] the standards data tables, indexed by table name
   def load_standards_database(data_directories = [])
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.standard', "Loading OpenStudio Standards data for #{template}")
-    @standards_data = {}
+    @standards_data = LazyStandardsData.new(self, data_directories)
 
-    # Load the JSON files from each directory
-    data_directories.each do |data_dir|
-      if __dir__[0] == ':' # Running from OpenStudio CLI
-        OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.standard', "Loading JSON files from OpenStudio CLI embedded directory #{data_dir}")
-        EmbeddedScripting.allFileNamesAsString.split(';').each do |file|
-          # Skip files outside of the specified directory
-          next unless file.start_with?("#{data_dir}/data")
-
-          # Skip files that are not JSON
-          next unless File.basename(file).match(/.*\.json/)
-
-          # Read the JSON file
-          data = JSON.parse(EmbeddedScripting.getFileAsString(file))
-          data.each_pair do |key, objs|
-            # Override the template in inherited files to match the instantiated template
-            objs.each do |obj|
-              if obj.key?('template')
-                obj['template'] = template
-              end
-            end
-            if @standards_data[key].nil?
-              OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.standard', "Adding #{key} from #{File.basename(file)}")
-            else
-              OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.standard', "Overriding #{key} with #{File.basename(file)}")
-            end
-            @standards_data[key] = objs
-          end
-        end
-      else
-        OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.standard', "Loading JSON files from #{data_dir}")
-        files = Dir.glob("#{data_dir}/data/*.json").select { |e| File.file? e }
-        files.each do |file|
-          data = JSON.parse(File.read(file))
-          data.each_pair do |key, objs|
-            # Override the template in inherited files to match the instantiated template
-            objs.each do |obj|
-              if obj.key?('template')
-                obj['template'] = template
-              end
-            end
-            if @standards_data[key].nil?
-              OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.standard', "Adding #{key} from #{File.basename(file)}")
-            else
-              OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.standard', "Overriding #{key} with #{File.basename(file)}")
-            end
-            @standards_data[key] = objs
-          end
-        end
-      end
-    end
-
-    # Check that standards data was loaded
-    if @standards_data.keys.empty?
+    # Check that standards data files were found
+    if @standards_data.empty?
       OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.standard', "OpenStudio Standards JSON data was not loaded correctly for #{template}.")
     end
     return @standards_data

--- a/test/ci_tests.txt
+++ b/test/ci_tests.txt
@@ -71,6 +71,7 @@ os_stds_methods/test_service_water_heating.rb
 os_stds_methods/test_daylighting_controls.rb
 os_stds_methods/test_space_type.rb
 os_stds_methods/test_misc.rb
+os_stds_methods/test_lazy_standards_data.rb
 os_stds_methods/test_radiant_controls.rb
 os_stds_methods/test_minimum_efficiency_lookups.rb
 

--- a/test/os_stds_methods/test_lazy_standards_data.rb
+++ b/test/os_stds_methods/test_lazy_standards_data.rb
@@ -1,0 +1,128 @@
+require_relative '../helpers/minitest_helper'
+
+# Tests for the on-demand loading of standards data tables
+class TestLazyStandardsData < Minitest::Test
+  STANDARDS_DIR = File.expand_path('../../lib/openstudio-standards/standards', __dir__)
+
+  # Directories that supply the ComStock 90.1-2013 data, most generic first
+  COMSTOCK_2013_DIRS = [
+    "#{STANDARDS_DIR}/ashrae_90_1",
+    "#{STANDARDS_DIR}/ashrae_90_1/ashrae_90_1_2013",
+    "#{STANDARDS_DIR}/ashrae_90_1/ashrae_90_1_2013/comstock_ashrae_90_1_2013"
+  ].freeze
+
+  # Loads every table from a list of directories up front, the way the
+  # library did before tables were parsed on demand
+  def eager_load(template, data_directories)
+    data = {}
+    data_directories.each do |data_dir|
+      Dir.glob("#{data_dir}/data/*.json").sort.each do |file|
+        JSON.parse(File.read(file)).each_pair do |key, objs|
+          objs.each { |obj| obj['template'] = template if obj.key?('template') }
+          data[key] = objs
+        end
+      end
+    end
+    data
+  end
+
+  def test_build_does_not_parse_any_table
+    std = Standard.build('90.1-2013')
+    data = std.standards_data
+    assert_kind_of Standard::LazyStandardsData, data
+    assert_empty data.loaded_tables
+    refute_empty data.keys
+    assert data.key?('space_types')
+    assert data.include?('boilers')
+    refute data.empty?
+  end
+
+  def test_table_is_parsed_on_first_access_and_reused
+    std = Standard.build('90.1-2013')
+    data = std.standards_data
+    space_types = data['space_types']
+    assert_kind_of Array, space_types
+    refute_empty space_types
+    assert_equal ['space_types'], data.loaded_tables
+    assert_same space_types, data['space_types']
+    assert data.loaded?('space_types')
+    refute data.loaded?('boilers')
+  end
+
+  def test_lazy_tables_match_eager_load
+    std = Standard.build('ComStock 90.1-2013')
+    eager = eager_load('ComStock 90.1-2013', COMSTOCK_2013_DIRS)
+    lazy = std.standards_data
+    assert_equal eager.keys.sort, lazy.keys.sort
+    eager.each_pair do |table_name, objs|
+      assert(objs == lazy[table_name], "table '#{table_name}' differs from the eagerly loaded table")
+    end
+    assert_equal eager.keys.sort, lazy.loaded_tables.sort
+  end
+
+  def test_most_specific_directory_supplies_the_table
+    data = Standard.build('ComStock 90.1-2013').standards_data
+    assert_equal COMSTOCK_2013_DIRS[2], File.dirname(File.dirname(data.file_for('space_types')))
+    assert_equal COMSTOCK_2013_DIRS[1], File.dirname(File.dirname(data.file_for('boilers')))
+    assert_equal COMSTOCK_2013_DIRS[0], File.dirname(File.dirname(data.file_for('schedules')))
+  end
+
+  def test_template_is_written_into_inherited_tables
+    data = Standard.build('ComStock 90.1-2013').standards_data
+    # construction_sets is inherited from the 90.1-2013 directory and stamped with the parent's template on disk
+    templates = data['construction_sets'].select { |obj| obj.key?('template') }.map { |obj| obj['template'] }.uniq
+    assert_equal ['ComStock 90.1-2013'], templates
+  end
+
+  def test_unknown_table_is_absent
+    std = Standard.build('90.1-2013')
+    data = std.standards_data
+    assert_nil data['no_such_table']
+    refute data.key?('no_such_table')
+    assert_equal 'fallback', data.fetch('no_such_table', 'fallback')
+    assert_raises(KeyError) { data.fetch('no_such_table') }
+    assert_empty std.standards_lookup_table_many(table_name: 'no_such_table')
+  end
+
+  def test_tables_can_be_stored_directly
+    data = Standard.build('90.1-2013').standards_data
+    user_buildings = [{ 'name' => 'Building 1', 'building_type_for_wwr' => 'Office' }]
+    data['userdata_building'] = user_buildings
+    assert data.key?('userdata_building')
+    assert_includes data.keys, 'userdata_building'
+    assert_same user_buildings, data['userdata_building']
+    assert_nil data.file_for('userdata_building')
+  end
+
+  def test_lookup_methods_read_lazy_tables
+    std = Standard.build('90.1-2013')
+    boilers = std.standards_lookup_table_many(table_name: 'boilers')
+    refute_empty boilers
+    assert_equal boilers.size, std.model_find_objects(std.standards_data['boilers'], {}).size
+  end
+
+  def test_hash_style_iteration_loads_every_table
+    data = Standard.build('90.1-2013').standards_data
+    as_hash = data.to_h
+    assert_kind_of Hash, as_hash
+    assert_equal data.keys.sort, as_hash.keys.sort
+    assert_equal data.keys.sort, data.loaded_tables.sort
+    assert_equal data.size, data.each_pair.count
+  end
+
+  # Every data file read by Standard#load_standards_database must hold exactly
+  # the table its file name promises, otherwise the table could not be found
+  # on demand. NECB data is loaded by its own code and has a different layout.
+  def test_every_data_file_holds_the_table_named_by_its_file_name
+    files = Dir.glob("#{STANDARDS_DIR}/**/data/*.json").reject { |file| file.include?('/necb/') }
+    assert_operator files.size, :>, 100, 'expected to find the data files of every non-NECB standard'
+
+    problems = []
+    files.each do |file|
+      table_name = Standard::LazyStandardsData.table_name_for(file)
+      keys = JSON.parse(File.read(file)).keys
+      problems << "#{file} holds #{keys.inspect} but its name promises '#{table_name}'" unless keys == [table_name]
+    end
+    assert_empty problems, problems.join("\n")
+  end
+end


### PR DESCRIPTION
Standard#load_standards_database parsed every JSON file in the template's data directories when the Standard was built. For 90.1-2013 that is 37 files and about 13 MB, roughly a second and 36 MB per build, and because each class in the inheritance chain calls the loader from its own initializer the parse ran two or three times per build. Callers that build a Standard to read a single table paid the full cost.

Standard::LazyStandardsData replaces the plain hash. Building a Standard now only lists the JSON files in each data directory and records which file supplies each table, later directories overriding earlier ones. A table's file is parsed the first time the table is requested, the template rewrite is applied then, and the result is memoized. The class answers the hash methods the library uses on standards data ([], []=, key?, keys, fetch, dig, to_h and friends), so the direct @standards_data call sites, the PRM user-data loader that stores extra tables, and the lookup helpers work unchanged. NECB standards keep their own loader and a plain hash.

Table names come from the file name suffix. Five suffixes differ from the table they hold (spc_typ, ext_ltg, prm_ext_ltg, ref_cases, ref_lnup) and are mapped through an alias table rather than renaming data files. The new test asserts that every non-NECB data file holds exactly the table its name resolves to, so a future mismatch fails CI instead of silently returning nil.

Building 90.1-2013 drops from about 1.1 s to 32 ms. Across the 74 CI test files that do not run a sizing run or simulation, total test time fell about 5 percent with the same pass/fail outcome on every file.

Pull request overview
---------------------


### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Method changes or additions
 - [ ] Data changes or additions
 - [ ] Added tests for added methods
 - [ ] If methods have been deprecated, update rest of code to use the new methods
 - [x] Documented new methods using [yard syntax](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md)
 - [ ] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [ ] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [x] All new and existing tests passes
 - [ ] If the code adds new `require` statements, ensure these are in core ruby or add to the gemspec

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a code review on GitHub
 - [ ] All related changes have been implemented: method additions, changes, tests
 - [ ] Check rubocop errors
 - [ ] Check yard doc errors
 - [ ] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If a new feature, test the new feature and try creative ways to break it
 - [ ] CI status: all green or justified
